### PR TITLE
add method passing only `chains`

### DIFF
--- a/src/autocorplot.jl
+++ b/src/autocorplot.jl
@@ -51,3 +51,4 @@ function autocorplot(chains::Chains, parameters; figure = nothing, kwargs...)
     return figure
 end
 
+autocorplot(chains::Chains; kwargs...) = autocorplot(chains, names(chains); kwargs...)

--- a/src/barplot.jl
+++ b/src/barplot.jl
@@ -40,3 +40,5 @@ function Makie.barplot(chains::Chains, parameters; figure = nothing, hidey=true,
 
     return figure
 end
+
+Makie.barplot(chains::Chains; kwargs...) = barplot(chains, names(chains); kwargs...)

--- a/src/density.jl
+++ b/src/density.jl
@@ -37,3 +37,5 @@ function Makie.density(chains::Chains, parameters; figure = nothing, hidey=true,
 
     return figure
 end
+
+Makie.density(chains::Chains; kwargs...) = density(chains, names(chains); kwargs...)

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -37,3 +37,5 @@ function Makie.hist(chains::Chains, parameters; figure = nothing, hidey=true, kw
 
     return figure
 end
+
+Makie.hist(chains::Chains; kwargs...) = hist(chains, names(chains); kwargs...)

--- a/src/meanplot.jl
+++ b/src/meanplot.jl
@@ -44,3 +44,5 @@ function meanplot(chains::Chains, parameters; figure = nothing, kwargs...)
 
     return figure
 end
+
+meanplot(chains::Chains; kwargs...) = meanplot(chains, names(chains); kwargs...)

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,5 +1,4 @@
-function Makie.plot(chains::Chains; figure = nothing, kwargs...)
-    parameters = names(chains)
+function Makie.plot(chains::Chains, parameters; figure = nothing, kwargs...)
     _, nparams, nchains = size(chains)
     color = get_colors(nchains; kwargs...)
     
@@ -33,6 +32,8 @@ function Makie.plot(chains::Chains; figure = nothing, kwargs...)
     
     return figure
 end
+
+Makie.plot(chains::Chains; kwargs...) = plot(chains, names(chains); kwargs...)
 
 function Makie.plot(chains::Chains, f::Vararg{Function,N}; figure = nothing, kwargs...) where N
     for f_i in string.(f)

--- a/src/ridgeline.jl
+++ b/src/ridgeline.jl
@@ -21,7 +21,7 @@ function ridgeline(chn::Chains, parameters; figure = nothing, kwargs...)
     samples = [vec(chn[:, parameter, :]) for parameter in parameters]
 
     if !(figure isa Figure)
-        figure = Figure(size = (400, 150 * length(parameters)))
+        figure = Figure(size = (400, min(150 * length(parameters), 2000)))
     end
 
     ax = Axis(figure[1, 1])
@@ -32,4 +32,4 @@ function ridgeline(chn::Chains, parameters; figure = nothing, kwargs...)
     return figure, ax, plt
 end
 
-# TODO ridgeline!(chn, parameters) with and without passing axis
+ridgeline(chains::Chains; kwargs...) = ridgeline(chains, names(chains); kwargs...)

--- a/src/traceplot.jl
+++ b/src/traceplot.jl
@@ -42,3 +42,5 @@ function traceplot(chains::Chains, parameters; figure = nothing, kwargs...)
     
     return figure
 end
+
+traceplot(chains::Chains; kwargs...) = traceplot(chains, names(chains); kwargs...)

--- a/src/trankplot.jl
+++ b/src/trankplot.jl
@@ -50,6 +50,8 @@ function trankplot(chains::Chains, parameters; figure = nothing, kwargs...)
     return figure
 end
 
+trankplot(chains::Chains; kwargs...) = trankplot(chains, names(chains); kwargs...)
+
 function bin_chain(mat::AbstractMatrix; bins = 20)
     ranks = denserank(mat)
     rank_range = range(extrema(ranks)..., length = bins)


### PR DESCRIPTION
Every plotting function can now also be used when passing only the `chains` argument, e.g., `autocorplot(chains)`. This will plot all parameters saved in this chain.